### PR TITLE
I2/board/cons coords

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -24,7 +24,7 @@ class Board
   end
 
   def valid_placement?(ship, coordinates)
-    valid_coordinate?(coordinates) && valid_length?(ship, coordinates) && !overlapping_coordinates?(coordinates) && consecutive_coordinates?(ship, coordinates)
+    valid_coordinate?(coordinates) && valid_length?(ship, coordinates) && !overlapping_coordinates?(coordinates) && consecutive_coordinates?(coordinates)
   end
 
   def valid_coordinate?(coordinates)
@@ -41,7 +41,7 @@ class Board
     end
   end
 
-  def consecutive_coordinates?(ship, coordinates)
+  def consecutive_coordinates?(coordinates)
     consecutive_row_coord = (coordinates.first..coordinates.last).to_a
     consecutive_row_letters = (coordinates.first[0]..coordinates.last[0]).to_a
     if on_same_row?(coordinates)

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -106,13 +106,12 @@ class BoardTest < Minitest::Test
   end
 
   def test_it_knows_a_ship_placement_has_consecutive_coordinates
-    refute @board.consecutive_coordinates?(@cruiser, ["A1", "A2", "A4"])
-    refute @board.consecutive_coordinates?(@submarine, ["A1", "C1"])
-    refute @board.consecutive_coordinates?(@cruiser, ["A3", "A2", "A1"])
-    refute @board.consecutive_coordinates?(@submarine, ["C1", "B1"])
-    assert_equal true, @board.consecutive_coordinates?(@cruiser, ["A1", "A2", "A3"])
-    assert_equal true, @board.consecutive_coordinates?(@cruiser, ["A1", "B1", "C1"])
-
+    refute @board.consecutive_coordinates?(["A1", "A2", "A4"])
+    refute @board.consecutive_coordinates?(["A1", "C1"])
+    refute @board.consecutive_coordinates?(["A3", "A2", "A1"])
+    refute @board.consecutive_coordinates?(["C1", "B1"])
+    assert_equal true, @board.consecutive_coordinates?(["A1", "A2", "A3"])
+    assert_equal true, @board.consecutive_coordinates?(["A1", "B1", "C1"])
   end
 
   def test_it_knows_a_ship_has_a_valid_placement
@@ -250,7 +249,7 @@ class BoardTest < Minitest::Test
      "3"=>["A3", "B3", "C3", "D3"],
      "4"=>["A4", "B4", "C4", "D4"]
    }
-   
+
     assert_equal expected, @board.columns
   end
 end


### PR DESCRIPTION
The ship variable in the board's consecutive coordinates method was not used inside the method so I believe it is not needed.

This PR does the following:

Removes the consecutive coordinate method ship parameter
Updates every invocation of this method to not pass in a ship object in both the test file and class.