### PR TITLE
Cell/render

### DIFF
--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -65,6 +65,16 @@ class CellTest < Minitest::Test
     assert_equal ".", @cell1.render
   end
 
+  def test_empty_renders_a_period_if_empty_and_not_fired_upon
+    assert_equal ".", @cell1.empty_render
+  end
+
+  def test_empty_renders_a_M_if_empty_and_fired_upon
+    @cell1.fire_upon
+
+    assert_equal "M", @cell1.empty_render
+  end
+
   def test_it_renders_a_M_if_empty_and_fired_upon
     @cell1.fire_upon
 
@@ -77,17 +87,36 @@ class CellTest < Minitest::Test
     assert_equal ".", @cell1.render
   end
 
-  def test_it_renders_H_if_occupied_and_fired_upon_provided
+  def test_occupied_renders_a_period_if_occupied_but_optional_argument_not_provided
+    @cell1.place_ship @cruiser
+
+    assert_equal ".", @cell1.occupied_render
+  end
+
+  def test_it_renders_H_if_occupied_and_fired_upon
     @cell1.place_ship @cruiser
     @cell1.fire_upon
 
     assert_equal "H", @cell1.render
   end
 
+  def test_occupied_rendes_H_if_occupied_and_fired_upon
+    @cell1.place_ship @cruiser
+    @cell1.fire_upon
+
+    assert_equal "H", @cell1.occupied_render
+  end
+
   def test_it_renders_S_if_occupied_and_optional_argument_provided
     @cell1.place_ship @cruiser
 
     assert_equal "S", @cell1.render(true)
+  end
+
+  def test_occupied_renders_S_if_occupied_and_optional_argument_provided
+    @cell1.place_ship @cruiser
+
+    assert_equal "S", @cell1.occupied_render(true)
   end
 
   def test_it_renders_a_X_if_occupied_and_ship_sunk
@@ -97,5 +126,14 @@ class CellTest < Minitest::Test
     @cell1.ship.hit
 
     assert_equal "X", @cell1.render
+  end
+
+  def test_occupied_renders_X_if_occupied_and_ship_sunk
+    @cell1.place_ship @cruiser
+    @cell1.ship.hit
+    @cell1.ship.hit
+    @cell1.ship.hit
+
+    assert_equal "X", @cell1.occupied_render
   end
 end


### PR DESCRIPTION
Broke up render into two helper methods: empty_render and occupied_render

Question... Should we keep the existing render tests which cover all the cases or modify those tests to test the helper functions?