### PR TITLE
I4/ai/crossguess

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -119,4 +119,22 @@ class Board
   def columns
     cells.keys.group_by { |coord| coord[1] }
   end
+
+  def adjacent_cells(coord)
+    cons_arrays = []
+    rows[coord[0]].each_cons(2) do |cons_elements|
+      cons_arrays << cons_elements
+    end
+
+    columns[coord[1]].each_cons(2) do |cons_elements|
+      cons_arrays << cons_elements
+    end
+
+    cons_arrays = cons_arrays.find_all do |ary|
+      ary.include?(coord)
+    end
+    cons_arrays.flatten!.uniq!
+    cons_arrays.delete(coord)
+    cons_arrays
+  end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -37,10 +37,10 @@ class Board
     end
   end
 
-  def get_cells_not_fired_upon(cells = @cells)
-    cells.select do |coord, cell|
+  def get_cells_not_fired_upon(cells = @cells.values)
+    cells.find_all do |cell|
       !cell.fired_upon?
-    end.values
+    end
   end
 
   def get_cells_hit
@@ -140,9 +140,11 @@ class Board
     cons_arrays
   end
 
-  def adjacent_cells(coord)
-    adjacent_coords(coord).map do |coord|
-      cells[coord]
-    end
+  def adjacent_cells(cells_array)
+    cells_array.map do |cell|
+      adjacent_coords(cell.coordinate).map do |coord|
+        @cells[coord]
+      end
+    end.flatten!
   end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -37,14 +37,10 @@ class Board
     end
   end
 
-  def get_cells_not_fired_upon
-    unhit_cells = []
-    @cells.keys.each do |key|
-      if !@cells[key].fired_upon?
-        unhit_cells << cells[key]
-      end
+  def get_cells_not_fired_upon(cells = @cells)
+    cells.keys.find_all do |key|
+      !cells[key].fired_upon?
     end
-    unhit_cells
   end
 
   def get_random_cell(cells)

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -43,6 +43,12 @@ class Board
     end
   end
 
+  def get_cells_hit
+    @cells.values.find_all do |cell|
+      cell.render == "H"
+    end
+  end
+
   def get_random_cell(cells)
     cells.shuffle[0]
   end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -137,4 +137,10 @@ class Board
     cons_arrays.delete(coord)
     cons_arrays
   end
+
+  def adjacent_cells(coord)
+    adjacent_coords(coord).map do |coord|
+      cells[coord]
+    end
+  end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -120,7 +120,7 @@ class Board
     cells.keys.group_by { |coord| coord[1] }
   end
 
-  def adjacent_cells(coord)
+  def adjacent_coords(coord)
     cons_arrays = []
     rows[coord[0]].each_cons(2) do |cons_elements|
       cons_arrays << cons_elements

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -38,9 +38,9 @@ class Board
   end
 
   def get_cells_not_fired_upon(cells = @cells)
-    cells.keys.find_all do |key|
-      !cells[key].fired_upon?
-    end
+    cells.select do |coord, cell|
+      !cell.fired_upon?
+    end.values
   end
 
   def get_cells_hit

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -10,7 +10,7 @@ class Turn
   def human_shot
     p enter_coord_msg
     input = gets.chomp.upcase
-    while (!@player2.board.valid_coordinate?(input))
+    while (!@player2.board.valid_coordinates?(input))
       p not_valid_coord_msg
       input = gets.chomp.upcase
     end
@@ -28,8 +28,15 @@ class Turn
   end
 
   def computer_shot
-    valid_cells = @player1.board.get_cells_not_fired_upon
-    random_cell = @player1.board.get_random_cell(valid_cells)
+    board = @player1.board
+    cells_hit = board.get_cells_hit
+    if !cells_hit.empty?
+      valid_cells = board.get_cells_not_fired_upon(board.adjacent_cells(cells_hit))
+      random_cell = valid_cells.sample
+    else
+      valid_cells = board.get_cells_not_fired_upon
+      random_cell = board.get_random_cell(valid_cells)
+    end
     random_cell.fire_upon
     @p2_shot_cell = random_cell
   end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -277,4 +277,24 @@ class BoardTest < Minitest::Test
 
     assert_equal 12, @board.get_cells_not_fired_upon.length
   end
+
+  def test_it_can_get_all_cells_adjacent_to_a_cell
+    coordinates1 = @board.adjacent_cells("B2")
+
+    assert coordinates1.include? "B1"
+    assert coordinates1.include? "B3"
+    assert coordinates1.include? "A2"
+    assert coordinates1.include? "C2"
+
+    coordinates2 = @board.adjacent_cells("D4")
+
+    assert coordinates2.include? "C4"
+    assert coordinates2.include? "D3"
+
+    coordinates3 = @board.adjacent_cells("C1")
+
+    assert coordinates3.include? "B1"
+    assert coordinates3.include? "D1"
+    assert coordinates3.include? "C2"
+  end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -278,6 +278,26 @@ class BoardTest < Minitest::Test
     assert_equal 12, @board.get_cells_not_fired_upon.length
   end
 
+  def test_it_can_get_cells_hit
+    @board.place(@cruiser, ["A1", "A2", "A3"])
+    @board.place(@submarine, ["B1", "B2"])
+    @board.cells['A1'].fire_upon
+
+    assert_equal 1, @board.get_cells_hit.length
+
+    @board.cells['A2'].fire_upon
+
+    assert_equal 2, @board.get_cells_hit.length
+
+    @board.cells['B1'].fire_upon
+
+    assert_equal 3, @board.get_cells_hit.length
+
+    @board.cells['B2'].fire_upon #submarine sunk "X"
+
+    assert_equal 2, @board.get_cells_hit.length
+  end
+
   def test_it_can_get_all_coords_adjacent_to_a_coord
     coordinates1 = @board.adjacent_coords("B2")
 

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -322,7 +322,14 @@ class BoardTest < Minitest::Test
   end
 
   def test_it_can_get_cells_from_coords
-    cells1 = @board.adjacent_cells("B1")
+    cells1 = @board.adjacent_cells([@board.cells["B1"], @board.cells["B2"]])
+
+    coordinates = cells1.map { |cell| cell.coordinate }
+    assert coordinates.include? "A1"
+    assert coordinates.include? "A2"
+    assert coordinates.include? "B3"
+    assert coordinates.include? "C1"
+    assert coordinates.include? "C2"
 
     assert_instance_of Cell, cells1.sample
   end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -297,4 +297,10 @@ class BoardTest < Minitest::Test
     assert coordinates3.include? "D1"
     assert coordinates3.include? "C2"
   end
+
+  def test_it_can_get_cells_from_coords
+    cells1 = @board.adjacent_cells("B1")
+
+    assert_instance_of Cell, cells1.sample
+  end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -278,20 +278,20 @@ class BoardTest < Minitest::Test
     assert_equal 12, @board.get_cells_not_fired_upon.length
   end
 
-  def test_it_can_get_all_cells_adjacent_to_a_cell
-    coordinates1 = @board.adjacent_cells("B2")
+  def test_it_can_get_all_coords_adjacent_to_a_coord
+    coordinates1 = @board.adjacent_coords("B2")
 
     assert coordinates1.include? "B1"
     assert coordinates1.include? "B3"
     assert coordinates1.include? "A2"
     assert coordinates1.include? "C2"
 
-    coordinates2 = @board.adjacent_cells("D4")
+    coordinates2 = @board.adjacent_coords("D4")
 
     assert coordinates2.include? "C4"
     assert coordinates2.include? "D3"
 
-    coordinates3 = @board.adjacent_cells("C1")
+    coordinates3 = @board.adjacent_coords("C1")
 
     assert coordinates3.include? "B1"
     assert coordinates3.include? "D1"

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -281,6 +281,9 @@ class BoardTest < Minitest::Test
   def test_it_can_get_cells_hit
     @board.place(@cruiser, ["A1", "A2", "A3"])
     @board.place(@submarine, ["B1", "B2"])
+
+    assert_equal 0, @board.get_cells_hit.length
+
     @board.cells['A1'].fire_upon
 
     assert_equal 1, @board.get_cells_hit.length


### PR DESCRIPTION
These changes allow the computer to narrow down the 'valid_cells' to guess on when one or more cells render as a hit "H".

Please play around with it a bit before merging to see if any errors pop up.

Changes made:
- Added adjacent_coords and adjacent_cells methods to board class (with tests)
- Refactored get_cells_not_fired_upon to take in an array of cells
- Created a get_cells_hit method within the board class (with test)
- Refactored computer_shot method